### PR TITLE
Feat/issue-47

### DIFF
--- a/BlueMosaic/src/components/dashboard/Achievements.tsx
+++ b/BlueMosaic/src/components/dashboard/Achievements.tsx
@@ -12,11 +12,12 @@ export const Achievements = () => {
 
   const handleToggle = (index: number, type: number) => {
     AchievementInfo.toggle(index, type);
-    console.log(index, type);
+    console.log(`index: ${index}, selected[${type}]`);
   };
 
   const handleToggleClick = () => {
     setToggleClick(!toggleClick);
+    console.log("toggleClick", toggleClick);
   };
 
   useEffect(() => {
@@ -82,10 +83,10 @@ export const Achievements = () => {
       {AchievementInfoStore.getState().cleaner[0] && (
         <AchievementsFish color="--googleblue-color" Click={handleToggleClick}>
           {toggleClick ? (
-            <span>{AchievementInfoStore.getState().cleaner[AchievementInfoStore.getState().select[0]]}</span>
+            <span onClick={handleToggleClick}>{AchievementInfoStore.getState().cleaner[AchievementInfoStore.getState().select[0]]}</span>
           ) : (
             AchievementInfoStore.getState().cleaner.map((item, index) => ( 
-              <span key={index} onClick={() => handleToggle(index, 0)}>{item}</span>
+              <span key={index} onClick={() => { handleToggle(index, 0); handleToggleClick(); }}>{item}</span>
             ))
           )}
         </AchievementsFish>

--- a/BlueMosaic/src/components/dashboard/Achievements.tsx
+++ b/BlueMosaic/src/components/dashboard/Achievements.tsx
@@ -157,6 +157,7 @@ export const AchievementsFish = styled.section`
     font-size: 0.825rem;
     font-weight: 700;
     line-height: 1.625rem;
+    padding: 0 1rem;
   }
 `;
 

--- a/BlueMosaic/src/components/dashboard/Achievements.tsx
+++ b/BlueMosaic/src/components/dashboard/Achievements.tsx
@@ -2,12 +2,22 @@ import styled from "@emotion/styled"
 import { Center } from "../../styles/Layout"
 import { AchievementsApis } from "../../hooks/useAchivementsQuery"
 import { AchievementInfoStore } from "../../stores/AchievementStore"
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 import { useStore } from "zustand"
 
 export const Achievements = () => {
 
   const AchievementInfo = useStore(AchievementInfoStore);
+  const [toggleClick, setToggleClick] = useState(false);
+
+  const handleToggle = (index: number) => {
+    AchievementInfo.toggle(index);
+    console.log(index);
+  };
+
+  const handleToggleClick = () => {
+    setToggleClick(!toggleClick);
+  };
 
   useEffect(() => {
     const fetchData = async () => {
@@ -41,13 +51,13 @@ export const Achievements = () => {
         if (value === true) {
           const cleanedKey = key.replace(/\d/g, '');
           if (cleanedKey.includes("Cleaner")) {
-            cleanerAchievements.push(cleanedKey);
+            cleanerAchievements.unshift(cleanedKey);
           } else if (cleanedKey.includes("Diver")) {
-            diverAchievements.push(cleanedKey);
+            diverAchievements.unshift(cleanedKey);
           } else if (cleanedKey.includes("Photographer")) {
-            photographerAchievements.push(cleanedKey);
+            photographerAchievements.unshift(cleanedKey);
           } else if (cleanedKey.includes("Pioneer")) {
-            pioneerAchievements.push(cleanedKey);
+            pioneerAchievements.unshift(cleanedKey);
           }
         }
       });
@@ -70,26 +80,33 @@ export const Achievements = () => {
   return (
     <AchievementsWrapper>
       {AchievementInfoStore.getState().cleaner[0] && (
-        <AchievementsFish color="--googleblue-color">
-          <span>{"experiencedCleaner012"}</span>
+        <AchievementsFish color="--googleblue-color" Click={handleToggleClick}>
+          {toggleClick ? (
+            <span>{AchievementInfoStore.getState().cleaner[AchievementInfoStore.getState().select[0]]}</span>
+          ) : (
+            AchievementInfoStore.getState().cleaner.map((item, index) => (
+              <span key={index} onClick={() => handleToggle(index)}>{item}</span>
+            ))
+          )}
         </AchievementsFish>
       )}
 
+
       {AchievementInfoStore.getState().diver[0] || (
         <AchievementsFish color="--googleyellow-color">
-          <span>{"dolphin"}</span>
+          <span>{AchievementInfoStore.getState().diver[AchievementInfoStore.getState().select[1]]}</span>
         </AchievementsFish>
       )}
 
       {AchievementInfoStore.getState().photographer[0] || (
         <AchievementsFish color="--googleRed-color">
-          <span>{"novicePhotographer"}</span>
+          <span>{AchievementInfoStore.getState().photographer[AchievementInfoStore.getState().select[2]]}</span>
         </AchievementsFish>
       )}
 
       {AchievementInfoStore.getState().pioneer[0] || (
         <AchievementsFish color="--googlegreen-color">
-          <span>{"pioneer"}</span>
+          <span>{AchievementInfoStore.getState().pioneer[AchievementInfoStore.getState().select[3]]}</span>
         </AchievementsFish>
       )}
     </AchievementsWrapper>
@@ -101,10 +118,9 @@ export const Achievements = () => {
 export const AchievementsFish = styled.section`
   max-height: 100%;
   display: flex;
+  flex-direction: column;
   flex-shrink: 0;
   align-self: stretch;
-  ${Center}
-  padding: 0.33rem 1.25rem;
   border-radius: 1.25rem;
   border: 2px solid var(--googleblue-color);
   background: var(--white-color);

--- a/BlueMosaic/src/components/dashboard/Achievements.tsx
+++ b/BlueMosaic/src/components/dashboard/Achievements.tsx
@@ -10,9 +10,9 @@ export const Achievements = () => {
   const AchievementInfo = useStore(AchievementInfoStore);
   const [toggleClick, setToggleClick] = useState(false);
 
-  const handleToggle = (index: number) => {
-    AchievementInfo.toggle(index);
-    console.log(index);
+  const handleToggle = (index: number, type: number) => {
+    AchievementInfo.toggle(index, type);
+    console.log(index, type);
   };
 
   const handleToggleClick = () => {
@@ -84,8 +84,8 @@ export const Achievements = () => {
           {toggleClick ? (
             <span>{AchievementInfoStore.getState().cleaner[AchievementInfoStore.getState().select[0]]}</span>
           ) : (
-            AchievementInfoStore.getState().cleaner.map((item, index) => (
-              <span key={index} onClick={() => handleToggle(index)}>{item}</span>
+            AchievementInfoStore.getState().cleaner.map((item, index) => ( 
+              <span key={index} onClick={() => handleToggle(index, 0)}>{item}</span>
             ))
           )}
         </AchievementsFish>

--- a/BlueMosaic/src/components/dashboard/Achievements.tsx
+++ b/BlueMosaic/src/components/dashboard/Achievements.tsx
@@ -67,36 +67,63 @@ export const Achievements = () => {
     fetchData();
   }, []);
 
-
   return (
     <AchievementsWrapper>
       {AchievementInfoStore.getState().cleaner[0] && (
-        <AchievementsFish>
+        <AchievementsFish color="--googleblue-color">
           <span>{"experiencedCleaner012"}</span>
         </AchievementsFish>
       )}
 
       {AchievementInfoStore.getState().diver[0] || (
-        <AchievementsFish>
+        <AchievementsFish color="--googleyellow-color">
           <span>{"dolphin"}</span>
         </AchievementsFish>
       )}
 
       {AchievementInfoStore.getState().photographer[0] || (
-        <AchievementsFish>
+        <AchievementsFish color="--googleRed-color">
           <span>{"novicePhotographer"}</span>
         </AchievementsFish>
       )}
 
       {AchievementInfoStore.getState().pioneer[0] || (
-        <AchievementsFish>
-          <span>{AchievementInfoStore.getState().pioneer[0]}</span>
+        <AchievementsFish color="--googlegreen-color">
+          <span>{"pioneer"}</span>
         </AchievementsFish>
       )}
     </AchievementsWrapper>
+  );
+};
 
-  )
-}
+// ... 이전 코드 ...
+
+export const AchievementsFish = styled.section`
+  max-height: 100%;
+  display: flex;
+  flex-shrink: 0;
+  align-self: stretch;
+  ${Center}
+  padding: 0.33rem 1.25rem;
+  border-radius: 1.25rem;
+  border: 2px solid var(--googleblue-color);
+  background: var(--white-color);
+  font-family: Poppins;
+
+  ${({ color }) => `
+    border-color: var(${color});
+  `}
+
+  span {
+    display: flex;
+    ${Center}
+    align-self: stretch;
+    font-feature-settings: 'clig' off, 'liga' off;
+    font-size: 0.825rem;
+    font-weight: 700;
+    line-height: 1.625rem;
+  }
+`;
 
 export const AchievementsWrapper = styled.section`
 display: flex;
@@ -104,29 +131,6 @@ justify-content: flex-end;
 align-items: center;
 gap: 0.9375rem;
 flex-shrink: 0;
-margin: 0.25rem;
+margin: 0.50rem;
 margin-left: auto;
-`
-
-export const AchievementsFish = styled.section`
-max-height: 100%;
-display: flex;
-flex-shrink: 0;
-align-self: stretch;
-${Center}
-padding: 0.63rem 1.25rem;
-border-radius: 1.25rem;
-border: 2px solid var(--googleblue-color);
-background: var(--white-color);
-
-span {
-  display: flex;
-  ${Center}
-  align-self: stretch;
-  font-feature-settings: 'clig' off, 'liga' off;
-  font-family: Poppins;
-  font-size: 1.125rem;
-  font-weight: 700;
-  line-height: 1.625rem;
-}
 `

--- a/BlueMosaic/src/components/dashboard/Achievements.tsx
+++ b/BlueMosaic/src/components/dashboard/Achievements.tsx
@@ -93,22 +93,40 @@ export const Achievements = () => {
       )}
 
 
-      {AchievementInfoStore.getState().diver[0] || (
-        <AchievementsFish color="--googleyellow-color">
-          <span>{AchievementInfoStore.getState().diver[AchievementInfoStore.getState().select[1]]}</span>
-        </AchievementsFish>
+      {AchievementInfoStore.getState().diver[0] && (
+        <AchievementsFish color="--googleyellow-color" Click={handleToggleClick}>
+        {toggleClick ? (
+          <span onClick={handleToggleClick}>{AchievementInfoStore.getState().diver[AchievementInfoStore.getState().select[1]]}</span>
+        ) : (
+          AchievementInfoStore.getState().diver.map((item, index) => ( 
+            <span key={index} onClick={() => { handleToggle(index, 0); handleToggleClick(); }}>{item}</span>
+          ))
+        )}
+      </AchievementsFish>
       )}
 
-      {AchievementInfoStore.getState().photographer[0] || (
-        <AchievementsFish color="--googleRed-color">
-          <span>{AchievementInfoStore.getState().photographer[AchievementInfoStore.getState().select[2]]}</span>
-        </AchievementsFish>
+      {AchievementInfoStore.getState().photographer[0] && (
+        <AchievementsFish color="--googleRed-color" Click={handleToggleClick}>
+        {toggleClick ? (
+          <span onClick={handleToggleClick}>{AchievementInfoStore.getState().photographer[AchievementInfoStore.getState().select[2]]}</span>
+        ) : (
+          AchievementInfoStore.getState().photographer.map((item, index) => ( 
+            <span key={index} onClick={() => { handleToggle(index, 0); handleToggleClick(); }}>{item}</span>
+          ))
+        )}
+      </AchievementsFish>
       )}
 
-      {AchievementInfoStore.getState().pioneer[0] || (
-        <AchievementsFish color="--googlegreen-color">
-          <span>{AchievementInfoStore.getState().pioneer[AchievementInfoStore.getState().select[3]]}</span>
-        </AchievementsFish>
+      {AchievementInfoStore.getState().pioneer[0] && (
+        <AchievementsFish color="--googlegreen-color" Click={handleToggleClick}>
+        {toggleClick ? (
+          <span onClick={handleToggleClick}>{AchievementInfoStore.getState().pioneer[AchievementInfoStore.getState().select[3]]}</span>
+        ) : (
+          AchievementInfoStore.getState().pioneer.map((item, index) => ( 
+            <span key={index} onClick={() => { handleToggle(index, 0); handleToggleClick(); }}>{item}</span>
+          ))
+        )}
+      </AchievementsFish>
       )}
     </AchievementsWrapper>
   );

--- a/BlueMosaic/src/components/dashboard/Achievements.tsx
+++ b/BlueMosaic/src/components/dashboard/Achievements.tsx
@@ -39,17 +39,19 @@ export const Achievements = () => {
       
       sortedAchievements.forEach(([key, value]) => {
         if (value === true) {
-          if (key.includes("Cleaner")) {
-            cleanerAchievements.unshift(key);
-          } else if (key.includes("Diver")) {
-            diverAchievements.unshift(key);
-          } else if (key.includes("Photographer")) {
-            photographerAchievements.unshift(key);
-          } else if (key.includes("Pioneer")) {
-            pioneerAchievements.unshift(key);
+          const cleanedKey = key.replace(/\d/g, '');
+          if (cleanedKey.includes("Cleaner")) {
+            cleanerAchievements.push(cleanedKey);
+          } else if (cleanedKey.includes("Diver")) {
+            diverAchievements.push(cleanedKey);
+          } else if (cleanedKey.includes("Photographer")) {
+            photographerAchievements.push(cleanedKey);
+          } else if (cleanedKey.includes("Pioneer")) {
+            pioneerAchievements.push(cleanedKey);
           }
         }
-      });      
+      });
+            
       
       AchievementInfo.setCleaner(cleanerAchievements);
       AchievementInfo.setDiver(diverAchievements);
@@ -70,23 +72,23 @@ export const Achievements = () => {
     <AchievementsWrapper>
       {AchievementInfoStore.getState().cleaner[0] && (
         <AchievementsFish>
-          <span>{AchievementInfoStore.getState().cleaner[0]}</span>
+          <span>{"experiencedCleaner012"}</span>
         </AchievementsFish>
       )}
 
-      {AchievementInfoStore.getState().diver[0] && (
+      {AchievementInfoStore.getState().diver[0] || (
         <AchievementsFish>
-          <span>{AchievementInfoStore.getState().diver[0]}</span>
+          <span>{"dolphin"}</span>
         </AchievementsFish>
       )}
 
-      {AchievementInfoStore.getState().photographer[0] && (
+      {AchievementInfoStore.getState().photographer[0] || (
         <AchievementsFish>
-          <span>{AchievementInfoStore.getState().photographer[0]}</span>
+          <span>{"novicePhotographer"}</span>
         </AchievementsFish>
       )}
 
-      {AchievementInfoStore.getState().pioneer[0] && (
+      {AchievementInfoStore.getState().pioneer[0] || (
         <AchievementsFish>
           <span>{AchievementInfoStore.getState().pioneer[0]}</span>
         </AchievementsFish>

--- a/BlueMosaic/src/components/dashboard/Achievements.tsx
+++ b/BlueMosaic/src/components/dashboard/Achievements.tsx
@@ -15,19 +15,48 @@ export const Achievements = () => {
         const data = await AchievementsApis.get();
         console.log("data", data);
 
-        // 가장 높은 등급이 0번째 오도록, 넣는다. 따라서 앞에다가 계속 넣어야한다.
-        // 자료는 다음과 같다 0은 파싱을 위한 기준
-        // 11, 12, 13 1이라는 카테고리의 1번째, 2번째, 3번째
-        // "sproutCleaner013": true, [2번째]
-        // "experiencedCleaner012": true, [1]번째
-        // "skilledCleaner011": true, [0]번째
+      const cleanerAchievements: string[] = [];
+      const diverAchievements: string[] = [];
+      const photographerAchievements: string[] = [];
+      const pioneerAchievements: string[] = [];
+      
+        const sortedAchievements = Object.entries(data)
+    .filter(([key, value]: [string, unknown]) => /0\d{2}$/.test(key) && typeof value === "boolean")
+    .sort((a, b) => {
+      const categoryA = parseInt(a[0][0]);
+      const categoryB = parseInt(b[0][0]);
+      const gradeA = parseInt(a[0].substring(1));
+      const gradeB = parseInt(b[0].substring(1));
 
-        //Cleaner
-        AchievementInfo.setCleaner([]);
-        //setDriver
-        AchievementInfo.setDiver([]);
-        AchievementInfo.setPhotographer([]);
-        AchievementInfo.setPioneer([]);
+      if (categoryA !== categoryB) {
+        return categoryA - categoryB; // 정렬 기준 1: 카테고리
+      } else {
+        return gradeB - gradeA; // 정렬 기준 2: 등급
+      }
+    }) as [string, boolean][];
+
+      console.log(sortedAchievements);
+      
+      sortedAchievements.forEach(([key, value]) => {
+        if (value === true) {
+          if (key.includes("Cleaner")) {
+            cleanerAchievements.unshift(key);
+          } else if (key.includes("Diver")) {
+            diverAchievements.unshift(key);
+          } else if (key.includes("Photographer")) {
+            photographerAchievements.unshift(key);
+          } else if (key.includes("Pioneer")) {
+            pioneerAchievements.unshift(key);
+          }
+        }
+      });      
+      
+      AchievementInfo.setCleaner(cleanerAchievements);
+      AchievementInfo.setDiver(diverAchievements);
+      AchievementInfo.setPhotographer(photographerAchievements);
+      AchievementInfo.setPioneer(pioneerAchievements);
+
+
       } catch (error) {
         console.error("Error fetching achievements:", error);
       }
@@ -39,22 +68,31 @@ export const Achievements = () => {
 
   return (
     <AchievementsWrapper>
-      <AchievementsFish>
-        <span>{AchievementInfoStore.getState().cleaner}</span>
-      </AchievementsFish>
+      {AchievementInfoStore.getState().cleaner[0] && (
+        <AchievementsFish>
+          <span>{AchievementInfoStore.getState().cleaner[0]}</span>
+        </AchievementsFish>
+      )}
 
-      <AchievementsFish>
-        <span>{AchievementInfoStore.getState().diver[0]}</span>
-      </AchievementsFish>
+      {AchievementInfoStore.getState().diver[0] && (
+        <AchievementsFish>
+          <span>{AchievementInfoStore.getState().diver[0]}</span>
+        </AchievementsFish>
+      )}
 
-      <AchievementsFish>
-        <span>{AchievementInfoStore.getState().photographer[0]}</span>
-      </AchievementsFish>
+      {AchievementInfoStore.getState().photographer[0] && (
+        <AchievementsFish>
+          <span>{AchievementInfoStore.getState().photographer[0]}</span>
+        </AchievementsFish>
+      )}
 
-      <AchievementsFish>
-        <span>{AchievementInfoStore.getState().pioneer[0]}</span>
-      </AchievementsFish>
+      {AchievementInfoStore.getState().pioneer[0] && (
+        <AchievementsFish>
+          <span>{AchievementInfoStore.getState().pioneer[0]}</span>
+        </AchievementsFish>
+      )}
     </AchievementsWrapper>
+
   )
 }
 

--- a/BlueMosaic/src/hooks/useAchivementsQuery.ts
+++ b/BlueMosaic/src/hooks/useAchivementsQuery.ts
@@ -10,7 +10,7 @@ export const AchievementsApis = {
   // 업적 조회
   get: async () => {
     try {
-      const res = await AchievementsApis.instance.post('/check/${userId: UserInfoStore.getState().userId}');
+      const res = await AchievementsApis.instance.post('/check', { userId: UserInfoStore.getState().userId });
       console.log(res);
       return res.data;
     } catch (error) {

--- a/BlueMosaic/src/hooks/useWasteQuery.ts
+++ b/BlueMosaic/src/hooks/useWasteQuery.ts
@@ -3,14 +3,14 @@ import { UserInfoStore } from '../stores/UserInfoStore';
 
 export const WasteApis = {
   instance: axios.create({
-    baseURL: 'http://localhost:8080/wastes',
+    baseURL: 'http://localhost:8080/waste',
     withCredentials: true,
   }),
 
   // 쓰레기 데이터 임시 생성하기
   create: async () => {
     try {
-      const res = await WasteApis.instance.post('/create', {
+      const res = await WasteApis.instance.post('/temp-data', {
         "userId": UserInfoStore.getState().userId,
         "plastic": 10,
         "styrofoam": 4,
@@ -25,15 +25,14 @@ export const WasteApis = {
     }
   },
 
-  // 획득한 점수 확인하기
-  get: async () => {
+  // 업로드하고 획득한 점수 확인하기
+  get: async (formData: FormData) => {
     try {
-      const res = await WasteApis.instance.post('/identify', { userId: UserInfoStore.getState().userId,
-      fileid: 1 });
+      const res = await WasteApis.instance.post('', formData);
       console.log(res);
       return res.data;
     } catch (error) {
-      console.error('Error fetching rooms:', error);
+      alert(`[Can't recognize] Please add a clearer picture`)
       throw error;
     }
   },

--- a/BlueMosaic/src/pages/Collection.tsx
+++ b/BlueMosaic/src/pages/Collection.tsx
@@ -28,7 +28,7 @@ export const Collection = () => {
         <Dashboard currentPage="Collection">
           {/* Grid */}
           <GridContainer>
-            {mediaData.map((item, key) => (
+            {/* {mediaData.map((item, key) => (
               <MiniFrameSVG
                 key={item.id}
                 imageUrl={item.base64EncodedImage}
@@ -36,7 +36,7 @@ export const Collection = () => {
                 date={item.fileName}
                 handleCircleClickParent={""}
               />
-            ))}
+            ))} */}
           </GridContainer>
         </Dashboard>
       </Container>

--- a/BlueMosaic/src/pages/Trash.tsx
+++ b/BlueMosaic/src/pages/Trash.tsx
@@ -4,11 +4,11 @@ import { Wrapper, Container} from "../styles/Layout"
 import HomeSVG from "../assets/HomeSVG.svg"
 import WaterWave from 'react-water-wave';
 import PolaroidSVG from "../assets/Polaroid.svg"
-import imageUrl from "../assets/UploadBackground.jpg"
 import { Frame } from "../components/FrameSVG";
 import { Toast } from "../components/Toast";
-import { MediaApis } from "../hooks/useMediaQuery";
 import { useNavigate } from 'react-router-dom';
+import { WasteApis } from '../hooks/useWasteQuery';
+WasteApis
 
 export const Trash = () => {
   const [showFrame, setShowFrame] = useState(false);
@@ -47,7 +47,9 @@ export const Trash = () => {
     }
 
     try {
-      const response = await MediaApis.upload(formData);
+      const response = await WasteApis.get(formData);
+      //test
+      //WasteApis.create();
       console.log("Upload Response:", response);
       setShowFrame(true);
     } catch (error) {

--- a/BlueMosaic/src/stores/AchievementStore.ts
+++ b/BlueMosaic/src/stores/AchievementStore.ts
@@ -13,7 +13,7 @@ export interface AchievementInfo {
   setPhotographer: (photographer: AchievementInfo['photographer']) => void;
   setPioneer: (pioneer: AchievementInfo['pioneer']) => void;
   setSelect: (select: AchievementInfo['select']) => void;
-  toggle: (index: number) => void;
+  toggle: (index: number, type: number) => void;
 }
 
 const createAchievementInfoStore = (set) => ({
@@ -28,12 +28,11 @@ const createAchievementInfoStore = (set) => ({
   setPhotographer: (photographer: AchievementInfo['photographer']) => set({ photographer }),
   setPioneer: (pioneer: AchievementInfo['pioneer']) => set({ pioneer }),
   setSelect: (select: AchievementInfo['select']) => set({ select }),
-  toggle: (index: number) => {
+  toggle: (index: number, type: number) => {
     set((state) => {
-      const newSelect = [...state.select];
-      const selected = newSelect.indexOf(index);
-      newSelect[selected] = 1 - newSelect[selected];
-      return { select: newSelect };
+      const prevSelect = [...state.select];
+      prevSelect[type] = index;
+      return { select: prevSelect };
     });
   },
 });

--- a/BlueMosaic/src/stores/AchievementStore.ts
+++ b/BlueMosaic/src/stores/AchievementStore.ts
@@ -1,16 +1,19 @@
 import { create } from "zustand";
-import { devtools, persist } from "zustand/middleware";
+import { devtools } from "zustand/middleware";
 
 export interface AchievementInfo {
   cleaner: string[];
   diver: string[];
   photographer: string[];
   pioneer: string[];
+  select: number[]; // [Cleaner, Diver, Photographer, Pioneer] Index
 
   setCleaner: (cleaner: AchievementInfo['cleaner']) => void;
   setDiver: (diver: AchievementInfo['diver']) => void;
   setPhotographer: (photographer: AchievementInfo['photographer']) => void;
   setPioneer: (pioneer: AchievementInfo['pioneer']) => void;
+  setSelect: (select: AchievementInfo['select']) => void;
+  toggle: (index: number) => void;
 }
 
 const createAchievementInfoStore = (set) => ({
@@ -18,16 +21,26 @@ const createAchievementInfoStore = (set) => ({
   diver: [""],
   photographer: [""],
   pioneer: [""],
+  select: [0, 0, 0, 0], // 각 항목에 대한 인덱스
 
   setCleaner: (cleaner: AchievementInfo['cleaner']) => set({ cleaner }),
   setDiver: (diver: AchievementInfo['diver']) => set({ diver }),
   setPhotographer: (photographer: AchievementInfo['photographer']) => set({ photographer }),
   setPioneer: (pioneer: AchievementInfo['pioneer']) => set({ pioneer }),
+  setSelect: (select: AchievementInfo['select']) => set({ select }),
+  toggle: (index: number) => {
+    set((state) => {
+      const newSelect = [...state.select];
+      const selected = newSelect.indexOf(index);
+      newSelect[selected] = 1 - newSelect[selected];
+      return { select: newSelect };
+    });
+  },
 });
 
 let AchievementInfoStoreTemp;
 
-//devtools
+// devtools
 if (import.meta.env.DEV) {
   AchievementInfoStoreTemp = create<AchievementInfo>()(devtools(createAchievementInfoStore, { name: 'AchievementInfo' }));
 } else {


### PR DESCRIPTION
### ✨ 작업 내용

---

![image](https://github.com/GDSC-KNU/3rd-sc-6-BlueMosaic-FE/assets/96682768/ff935507-b150-4e84-9ca7-4daa4f667a1e)


![toggleIndexComplete](https://github.com/GDSC-KNU/3rd-sc-6-BlueMosaic-FE/assets/96682768/75a9e941-23e1-48dd-bd54-ae0bdd7dbc3e)

- [x] 업적기능
- [x] #47
- [x] API 제작 확인
- [x] 업적 컴포넌트 제작
- [x] 업적마다 배지 색깔 변경
- [x] 업적 토글바, 이전 배지 항목으로 선택하여 다시 사용 가능하게하기  (디자인이 이쁜 명패쓰듯이)
- [x] 클릭가능하게하고, 클릭시 zustand로 가진 모든 업적 보이게하기
- [x] 선택하면 그 업적으로 보이게하기
- [x] toggle의 Store을 어떻게 관리해야 효율적인지 고민 selectNumber: string[] ??
- [x] Collection에 추가


### ✨ 참고 사항

---


-
### ⏰ 현재 버그

---

- 쓰레기 전송 API 로직에 문제 발생

### ✏ Git Close

close #38  #47